### PR TITLE
Added support for NaN and Infinity values

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -1,6 +1,7 @@
 #include "value.h"
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include "memory.h"
 #include "object.h"
 
@@ -25,6 +26,18 @@ void writeValueArray(VM* vm, ValueArray* array, Value value) {
 	array->values[array->count++] = value;
 }
 
+void printNumber(double value) {
+	if (isinf(value)) {
+		printf("%sInfinity", signbit(value) ? "-" : "");
+	}
+	else if (isnan(value)) {
+		printf("NaN");
+	}
+	else {
+		printf("%g", value);
+	}
+}
+
 void printValue(Value value) {
 	switch (value.type) {
 		case VAL_BOOL: 
@@ -34,7 +47,7 @@ void printValue(Value value) {
 			printf("null");
 			break;
 		case VAL_NUMBER:
-			printf("%g", AS_NUMBER(value)); 
+			printNumber(AS_NUMBER(value)); 
 			break;
 		case VAL_OBJ:
 			printObject(value);

--- a/src/vm.c
+++ b/src/vm.c
@@ -47,6 +47,8 @@ void initVM(VM* vm) {
 	vm->constructorString = NULL; // GC Call
 	vm->constructorString = copyString(vm, "constructor", 11);
 
+	tableSet(vm, &vm->globals, copyString(vm, "NaN", 3), NUMBER_VAL(nan("0")));
+	tableSet(vm, &vm->globals, copyString(vm, "Infinity", 8), NUMBER_VAL(INFINITY));
 	defineNative(vm, "clock", clockNative);
 	defineNative(vm, "print", printNative);
 }


### PR DESCRIPTION
Two globals have been defined:
```
NaN - defined as C's nan("0") (math.h)
Infinity - defined as C's INFINITY (math.h)
```
Also added support for printing said values (the %g implementation may not be the same across platforms and is unintuitive).
Any NaN value is represented as `NaN` regardless of sign or quiet / signalling.
Positive Infinity is represented as `Infinity` and negative Infinity as `-Infinity`.