### PR TITLE
String coercion

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -181,7 +181,7 @@ static ObjFunction* endCompiler(Compiler* compiler) {
 	ObjFunction* function = compiler->function;
 #ifdef DEBUG_PRINT_CODE
 	if (!compiler->parser->hadError) {
-		disassembleChunk(currentChunk(compiler), function->name != NULL ? function->name->chars : "<script>");
+		disassembleChunk(compiler->vm, currentChunk(compiler), function->name != NULL ? function->name->chars : "<script>");
 	}
 #endif
 	return function;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -493,7 +493,7 @@ static void string(Compiler* compiler, bool canAssign) {
 		emitConstant(compiler, OBJ_VAL(takeString(compiler->vm, dest, length)));
 	}
 	else {
-		dest = GROW_ARRAY(compiler->vm, char, dest, length, newLength + 1);
+		dest = GROW_ARRAY(compiler->vm, char, dest, length + 1, newLength + 1);
 		emitConstant(compiler, OBJ_VAL(takeString(compiler->vm, dest, newLength)));
 	}
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -34,7 +34,7 @@ static int constantInstruction(const char* name, Chunk* chunk, int offset) {
 	size_t size = readUleb128(&chunk->code[offset + 1], &constant);
 
 	printf("%-16s %4zu '", name, constant);
-	printValue(chunk->constants.values[constant]);
+	printValueRepr(chunk->constants.values[constant]);
 	printf("'\n");
 	return offset + (int)size + 1;
 }
@@ -57,7 +57,7 @@ static int invokeInstruction(const char* name, Chunk* chunk, int offset) {
 	size_t size = readUleb128(&chunk->code[offset + 1], &constant);
 	uint8_t argCount = chunk->code[offset + 2];
 	printf("%-16s (%d args) %4zu '", name, argCount, constant);
-	printValue(chunk->constants.values[constant]);
+	printValueRepr(chunk->constants.values[constant]);
 	printf("'\n");
 	return offset + size + 2;
 }
@@ -106,7 +106,7 @@ int disassembleInstruction(Chunk* chunk, int offset) {
 			offset++;
 			uint8_t constant = chunk->code[offset++];
 			printf("%-16s %4d ", "CLOSURE", constant);
-			printValue(chunk->constants.values[constant]);
+			printValueRepr(chunk->constants.values[constant]);
 			printf("\n");
 
 			ObjFunction* function = AS_FUNCTION(chunk->constants.values[constant]);

--- a/src/debug.h
+++ b/src/debug.h
@@ -2,6 +2,6 @@
 
 #include "chunk.h"
 
-void disassembleChunk(Chunk* chunk, const char* name);
-int disassembleInstruction(Chunk* chunk, int offset);
+void disassembleChunk(VM* vm, Chunk* chunk, const char* name);
+int disassembleInstruction(VM* vm, Chunk* chunk, int offset);
 size_t getLine(LineNumberTable* table, size_t index);

--- a/src/memory.c
+++ b/src/memory.c
@@ -23,7 +23,7 @@ void* reallocate(VM* vm, void* pointer, size_t oldSize, size_t newSize) {
 #endif
 	}
 
-	if (vm->bytesAllocated > vm->nextGC) {
+	if (vm->bytesAllocated > vm->nextGC && vm->shouldGC) {
 		collectGarbage(vm);
 	}
 
@@ -238,6 +238,7 @@ static void freeObject(VM* vm, Obj* object) {
 }
 
 void freeObjects(VM* vm) {
+	vm->shouldGC = false;
 	Obj* object = vm->objects;
 	while (object != NULL) {
 		Obj* next = object->next;
@@ -245,4 +246,5 @@ void freeObjects(VM* vm) {
 		object = next;
 	}
 	free(vm->grayStack);
+	vm->shouldGC = true;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -167,40 +167,19 @@ ObjString* objectToString(VM* vm, Value value) {
 	}
 }
 
-static void printFunction(ObjFunction* function) {
-	if (function->name == NULL) {
-		printf("<script>");
-		return;
-	}
-	printf("<function %s>", function->name->chars);
-}
-
-void printObjectRepr(Value value) {
+ObjString* objectToRepr(VM* vm, Value value) {
 	switch (OBJ_TYPE(value)) {
 		case OBJ_BOUND_METHOD:
-			printFunction(AS_BOUND_METHOD(value)->method->function);
-			break;
 		case OBJ_CLASS:
-			printf("<class %s>", AS_CLASS(value)->name->chars);
-			break;
-		case OBJ_INSTANCE:
-			printf("<instance %s>", AS_INSTANCE(value)->klass->name->chars);
-			break;
 		case OBJ_CLOSURE:
-			printFunction(AS_CLOSURE(value)->function);
-			break;
 		case OBJ_FUNCTION:
-			printFunction(AS_FUNCTION(value));
-			break;
 		case OBJ_NATIVE:
-			printf("<native function>");
-			break;
-		case OBJ_STRING:
-			printf("\"%s\"", AS_CSTRING(value));
-			break;
 		case OBJ_UPVALUE:
-			printf("upvalue");
-			break;
+			return objectToString(vm, value);
+		case OBJ_INSTANCE:
+			return makeStringf(vm, "<instance %s>", AS_INSTANCE(value)->klass->name->chars);
+		case OBJ_STRING:
+			return makeStringf(vm, "\"%s\"", AS_CSTRING(value));
 		default: return; // Unreachable.
 	}
 }

--- a/src/object.c
+++ b/src/object.c
@@ -175,7 +175,7 @@ static void printFunction(ObjFunction* function) {
 	printf("<function %s>", function->name->chars);
 }
 
-void printObject(Value value) {
+void printObjectRepr(Value value) {
 	switch (OBJ_TYPE(value)) {
 		case OBJ_BOUND_METHOD:
 			printFunction(AS_BOUND_METHOD(value)->method->function);
@@ -196,7 +196,7 @@ void printObject(Value value) {
 			printf("<native function>");
 			break;
 		case OBJ_STRING:
-			printf("%s", AS_CSTRING(value));
+			printf("\"%s\"", AS_CSTRING(value));
 			break;
 		case OBJ_UPVALUE:
 			printf("upvalue");

--- a/src/object.h
+++ b/src/object.h
@@ -87,7 +87,7 @@ ObjString* takeString(VM* vm, char* chars, size_t length);
 ObjString* copyString(VM* vm, const char* chars, size_t length);
 ObjString* makeStringf(VM* vm, const char* format, ...);
 ObjString* objectToString(VM* vm, Value value);
-void printObject(Value value);
+void printObjectRepr(Value value);
 
 static inline bool isObjType(Value value, ObjType type) {
 	return IS_OBJ(value) && AS_OBJ(value)->type == type;

--- a/src/object.h
+++ b/src/object.h
@@ -87,7 +87,7 @@ ObjString* takeString(VM* vm, char* chars, size_t length);
 ObjString* copyString(VM* vm, const char* chars, size_t length);
 ObjString* makeStringf(VM* vm, const char* format, ...);
 ObjString* objectToString(VM* vm, Value value);
-void printObjectRepr(Value value);
+ObjString* objectToRepr(VM* vm, Value value);
 
 static inline bool isObjType(Value value, ObjType type) {
 	return IS_OBJ(value) && AS_OBJ(value)->type == type;

--- a/src/object.h
+++ b/src/object.h
@@ -30,7 +30,7 @@ struct ObjFunction {
 	ObjString* name;
 };
 
-typedef Value(*NativeFn)(uint8_t argCount, Value* args);
+typedef Value(*NativeFn)(VM* vm, uint8_t argCount, Value* args);
 
 typedef struct {
 	Obj obj;
@@ -85,6 +85,8 @@ ObjClosure* newClosure(VM* vm, ObjFunction* function);
 ObjUpvalue* newUpvalue(VM* vm, Value* slot);
 ObjString* takeString(VM* vm, char* chars, size_t length);
 ObjString* copyString(VM* vm, const char* chars, size_t length);
+ObjString* makeStringf(VM* vm, const char* format, ...);
+ObjString* objectToString(VM* vm, Value value);
 void printObject(Value value);
 
 static inline bool isObjType(Value value, ObjType type) {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -81,8 +81,13 @@ static void skipWhitespace(Scanner* scanner) {
 
 static Token string(Scanner* scanner) {
 	char ending = scanner->current[-1];
-	while (peek(scanner) != ending && !isAtEnd(scanner)) {
+	bool escape = false;
+	while (!isAtEnd(scanner)) {
+		if (peek(scanner) == ending && !escape) break;
+
 		if (peek(scanner) == '\n') scanner->line++;
+		if (escape) escape = false;
+		if (peek(scanner) == '\\') escape = true;
 		advance(scanner);
 	}
 	if (isAtEnd(scanner)) return errorToken(scanner, "Unterminated string.");

--- a/src/value.c
+++ b/src/value.c
@@ -38,6 +38,29 @@ void printNumber(double value) {
 	}
 }
 
+ObjString* numberToString(VM* vm, double value) {
+	if (isinf(value)) {
+		return makeStringf(vm, "%sInfinity", signbit(value) ? "-" : "");
+	}
+	else if (isnan(value)) {
+		return copyString(vm, "NaN", 3);
+	}
+	return makeStringf(vm, "%g", value);
+}
+
+ObjString* valueToString(VM* vm, Value value) {
+	switch (value.type) {
+		case VAL_BOOL:
+			return AS_BOOL(value) ? copyString(vm, "true", 4) : copyString(vm, "false", 5);
+		case VAL_NULL:
+			return copyString(vm, "null", 4);
+		case VAL_NUMBER:
+			return numberToString(vm, AS_NUMBER(value));
+		case VAL_OBJ:
+			return objectToString(vm, value);
+	}
+}
+
 void printValue(Value value) {
 	switch (value.type) {
 		case VAL_BOOL: 

--- a/src/value.c
+++ b/src/value.c
@@ -61,7 +61,7 @@ ObjString* valueToString(VM* vm, Value value) {
 	}
 }
 
-void printValue(Value value) {
+void printValueRepr(Value value) {
 	switch (value.type) {
 		case VAL_BOOL: 
 			printf(AS_BOOL(value) ? "true" : "false");
@@ -73,7 +73,7 @@ void printValue(Value value) {
 			printNumber(AS_NUMBER(value)); 
 			break;
 		case VAL_OBJ:
-			printObject(value);
+			printObjectRepr(value);
 			break;
 	}
 }

--- a/src/value.c
+++ b/src/value.c
@@ -61,20 +61,14 @@ ObjString* valueToString(VM* vm, Value value) {
 	}
 }
 
-void printValueRepr(Value value) {
+ObjString* valueToRepr(VM* vm, Value value) {
 	switch (value.type) {
 		case VAL_BOOL: 
-			printf(AS_BOOL(value) ? "true" : "false");
-			break;
 		case VAL_NULL:
-			printf("null");
-			break;
 		case VAL_NUMBER:
-			printNumber(AS_NUMBER(value)); 
-			break;
+			return valueToString(vm, value);
 		case VAL_OBJ:
-			printObjectRepr(value);
-			break;
+			return objectToRepr(vm, value);
 	}
 }
 

--- a/src/value.h
+++ b/src/value.h
@@ -35,6 +35,7 @@ void initValueArray(ValueArray* array);
 void freeValueArray(VM* vm, ValueArray* array);
 void writeValueArray(VM* vm, ValueArray* array, Value value);
 void printValue(Value value);
+ObjString* valueToString(VM* vm, Value value);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);
 

--- a/src/value.h
+++ b/src/value.h
@@ -34,7 +34,7 @@ typedef struct {
 void initValueArray(ValueArray* array);
 void freeValueArray(VM* vm, ValueArray* array);
 void writeValueArray(VM* vm, ValueArray* array, Value value);
-void printValue(Value value);
+void printValueRepr(Value value);
 ObjString* valueToString(VM* vm, Value value);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);

--- a/src/value.h
+++ b/src/value.h
@@ -34,7 +34,7 @@ typedef struct {
 void initValueArray(ValueArray* array);
 void freeValueArray(VM* vm, ValueArray* array);
 void writeValueArray(VM* vm, ValueArray* array, Value value);
-void printValueRepr(Value value);
+ObjString* valueToRepr(VM* vm, Value value);
 ObjString* valueToString(VM* vm, Value value);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);

--- a/src/vm.c
+++ b/src/vm.c
@@ -19,7 +19,7 @@ static Value clockNative(VM* vm, uint8_t argCount, Value* args) {
 
 static Value printNative(VM* vm, uint8_t argCount, Value* args) {
 	for (size_t i = 0; i < argCount; i++) {
-		printValue(args[i]);
+		printf("%s", valueToString(vm, args[i])->chars);
 		printf(" ");
 	}
 	printf("\n");
@@ -325,7 +325,7 @@ static InterpreterResult run(VM* vm) {
 		printf("     ");
 		for (Value* slot = vm->stack; slot < vm->stackTop; slot++) {
 			printf("[ ");
-			printValue(*slot);
+			printValueRepr(*slot);
 			printf(" ]");
 		}
 		printf("\n");

--- a/src/vm.c
+++ b/src/vm.c
@@ -261,8 +261,8 @@ static bool invoke(VM* vm, ObjString* name, uint8_t argCount) {
 }
 
 static void concatenate(VM* vm) {
-	ObjString* b = AS_STRING(peek(vm, 0));
-	ObjString* a = AS_STRING(peek(vm, 1));
+	ObjString* b = valueToString(vm, peek(vm, 0));
+	ObjString* a = valueToString(vm, peek(vm, 1));
 
 	size_t length = a->length + b->length;
 	char* chars = ALLOCATE(vm, char, length + 1);
@@ -473,7 +473,7 @@ static InterpreterResult run(VM* vm) {
 				push(vm, NUMBER_VAL(-AS_NUMBER(pop(vm)))); 
 				break;
 			case OP_ADD: {
-				if (IS_STRING(peek(vm, 0)) && IS_STRING(peek(vm, 1))) {
+				if (IS_STRING(peek(vm, 0)) || IS_STRING(peek(vm, 1))) {
 					concatenate(vm);
 				}
 				else if (IS_NUMBER(peek(vm, 0)) && IS_NUMBER(peek(vm, 1))) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -31,6 +31,11 @@ static Value toStringNative(VM* vm, uint8_t argCount, Value* args) {
 	return OBJ_VAL(valueToString(vm, args[0]));
 }
 
+static Value reprNative(VM* vm, uint8_t argCount, Value* args) {
+	//TODO arg count safety
+	return OBJ_VAL(valueToRepr(vm, args[0]));
+}
+
 static void resetStack(VM* vm) {
 	vm->stackTop = vm->stack;
 	vm->frameCount = 0;
@@ -63,6 +68,7 @@ void initVM(VM* vm) {
 	tableSet(vm, &vm->globals, copyString(vm, "NaN", 3), NUMBER_VAL(nan("0")));
 	tableSet(vm, &vm->globals, copyString(vm, "Infinity", 8), NUMBER_VAL(INFINITY));
 	defineNative(vm, "toString", toStringNative);
+	defineNative(vm, "repr", reprNative);
 	defineNative(vm, "clock", clockNative);
 	defineNative(vm, "print", printNative);
 }
@@ -325,12 +331,12 @@ static InterpreterResult run(VM* vm) {
 		printf("     ");
 		for (Value* slot = vm->stack; slot < vm->stackTop; slot++) {
 			printf("[ ");
-			printValueRepr(*slot);
+			printf("%s", valueToRepr(vm, *slot)->chars);
 			printf(" ]");
 		}
 		printf("\n");
 
-		disassembleInstruction(&frame->closure->function->chunk, (int)(frame->ip - frame->closure->function->chunk.code));
+		disassembleInstruction(vm, &frame->closure->function->chunk, (int)(frame->ip - frame->closure->function->chunk.code));
 #endif
 
 		uint8_t instruction;

--- a/src/vm.h
+++ b/src/vm.h
@@ -26,6 +26,7 @@ struct VM {
 	ObjUpvalue* openUpvalues;
 	size_t bytesAllocated;
 	size_t nextGC;
+	bool shouldGC;
 	Obj* objects;
 	size_t grayCount;
 	size_t grayCapacity;


### PR DESCRIPTION
### String Coercion
String coercion during addition has been implemented, that is, when addition is performed with a string as an operand the other operand's type is coerced to match the string.

Example:
```
print("2 + 4 = " + (2 + 4)); // 6
```
### Explicit String Conversion
Explicit type conversion to a string can be done with the global `toString` function.
Example:
```
var x = toString({}); // "<instance Object>"
```
### Escape Sequences
Escape sequences are supported with strings:
| Escape | Inserted character |
| ------- | -------------------- |
| \\n | Newline |
| \\\\ | Backslash character |
| \\r | Carriage return |
| \\t | Horizontal tab |
| \\b | Backspace |
| \\f | Formfeed Page Break |
| \\' | A single quote character |
| \\" | A double quote character |

### Representation
Each value has a representation which it can be converted to. These are used for internal debugging.
They are accessible to the user via the global `repr` function.
Most values `repr` and `toString` are equivalant.

The most obvious exception is a string. A `repr` of a string surrounds the string with double quotes (") and unescapes characters.
Example:
`print(repr("Hello\nWorld"));` prints `"Hello\nWorld"`
Whereas:
`print(toString("Hello\nWorld"));` prints
```
Hello
World
```
(Note that `print` will automatically use the `toString` form).