### PR TITLE
Better natives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,4 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Add source to this project's executable.
-add_executable (Dragon "src/Dragon.c"  "src/common.h" "src/chunk.h" "src/chunk.c" "src/memory.h" "src/memory.c" "src/debug.h" "src/debug.c" "src/value.h" "src/value.c" "src/vm.h" "src/vm.c" "src/compiler.h" "src/compiler.c" "src/scanner.h" "src/scanner.c" "src/object.c" "src/object.h" "src/table.h" "src/table.c" "src/leb128.c" "src/leb128.h")
+add_executable (Dragon "src/Dragon.c"  "src/common.h" "src/chunk.h" "src/chunk.c" "src/memory.h" "src/memory.c" "src/debug.h" "src/debug.c" "src/value.h" "src/value.c" "src/vm.h" "src/vm.c" "src/compiler.h" "src/compiler.c" "src/scanner.h" "src/scanner.c" "src/object.c" "src/object.h" "src/table.h" "src/table.c" "src/leb128.c" "src/leb128.h" "src/natives.c" "src/natives.h")

--- a/src/common.h
+++ b/src/common.h
@@ -5,9 +5,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef _DEBUG
 #define DEBUG_PRINT_CODE
 #define DEBUG_TRACE_EXECUTION
 // Causes a few bugs, uncommon, should be fixed, not priority at the current time
 //#define DEBUG_STRESS_GC
 //#define DEBUG_LOG_GC
+#endif
 #define UINT8_COUNT (UINT8_MAX + 1)

--- a/src/natives.c
+++ b/src/natives.c
@@ -1,5 +1,6 @@
 #include "natives.h"
 #include "value.h"
+#include <stdio.h>
 #include <time.h>
 #include <math.h>
 
@@ -9,7 +10,9 @@ static Value clockNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) 
 
 static Value printNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
 	for (size_t i = 0; i < argCount; i++) {
-		printf("%s", valueToString(vm, args[i])->chars);
+		ObjString* value = valueToString(vm, args[i], hasError);
+		if (*hasError) return NULL_VAL;
+		printf("%s", value->chars);
 		printf(" ");
 	}
 	printf("\n");
@@ -17,7 +20,7 @@ static Value printNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) 
 }
 
 static Value toStringNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	return OBJ_VAL(valueToString(vm, args[0]));
+	return OBJ_VAL(valueToString(vm, args[0], hasError));
 }
 
 static Value reprNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {

--- a/src/natives.c
+++ b/src/natives.c
@@ -1,0 +1,50 @@
+#include "natives.h"
+#include "value.h"
+#include <time.h>
+#include <math.h>
+
+static Value clockNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
+	return NUMBER_VAL((double)clock() / CLOCKS_PER_SEC);
+}
+
+static Value printNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
+	for (size_t i = 0; i < argCount; i++) {
+		printf("%s", valueToString(vm, args[i])->chars);
+		printf(" ");
+	}
+	printf("\n");
+	return NULL_VAL;
+}
+
+static Value toStringNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
+	return OBJ_VAL(valueToString(vm, args[0]));
+}
+
+static Value reprNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
+	return OBJ_VAL(valueToRepr(vm, args[0]));
+}
+
+static Value sqrtNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
+	if (!IS_NUMBER(args[0])) {
+		runtimeError(vm, "Expected number as first argument to sqrt.");
+		*hasError = true;
+		return NULL_VAL;
+	}
+	return NUMBER_VAL(sqrt(AS_NUMBER(args[0])));
+}
+
+void defineGlobalNatives(VM* vm) {
+	defineNative(vm, "toString", 1, toStringNative);
+	defineNative(vm, "repr", 1, reprNative);
+	defineNative(vm, "clock", 0, clockNative);
+	defineNative(vm, "sqrt", 1, sqrtNative);
+	defineNative(vm, "print", 1, printNative);
+}
+
+void defineNative(VM* vm, const char* name, size_t arity, NativeFn function) {
+	push(vm, OBJ_VAL(copyString(vm, name, strlen(name))));
+	push(vm, OBJ_VAL(newNative(vm, arity, function)));
+	tableSet(vm, &vm->globals, AS_STRING(vm->stack[0]), vm->stack[1]);
+	pop(vm);
+	pop(vm);
+}

--- a/src/natives.h
+++ b/src/natives.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "object.h"
+#include "vm.h"
+void defineNative(VM* vm, const char* name, size_t arity, NativeFn function);
+void defineGlobalNatives(VM* vm);

--- a/src/natives.h
+++ b/src/natives.h
@@ -1,5 +1,8 @@
 #pragma once
+#include "common.h"
 #include "object.h"
 #include "vm.h"
+
+Value callDragonFromNative(VM* vm, Value value, bool* hasError);
 void defineNative(VM* vm, const char* name, size_t arity, NativeFn function);
 void defineGlobalNatives(VM* vm);

--- a/src/natives.h
+++ b/src/natives.h
@@ -3,6 +3,6 @@
 #include "object.h"
 #include "vm.h"
 
-Value callDragonFromNative(VM* vm, Value value, bool* hasError);
+Value callDragonFromNative(VM* vm, Value callee, size_t argCount, bool* hasError);
 void defineNative(VM* vm, const char* name, size_t arity, NativeFn function);
 void defineGlobalNatives(VM* vm);

--- a/src/object.c
+++ b/src/object.c
@@ -146,30 +146,38 @@ ObjString* functionToString(VM* vm, ObjFunction* function) {
 	return makeStringf(vm, "<function %s>", function->name->chars);
 }
 
-ObjString* instanceToString(VM* vm, ObjInstance* instance) {
+ObjString* instanceToString(VM* vm, ObjInstance* instance, bool* hasError) {
 	Value method;
 	if (tableGet(&instance->fields, copyString(vm, "toString", 8), &method)) {
-		bool hasError = false;
-		Value stringForm = callDragonFromNative(vm, method, 0, &hasError);
-		if (!hasError) return AS_STRING(stringForm);
+		Value stringForm = callDragonFromNative(vm, method, 0, hasError);
+		if (!IS_STRING(stringForm)) { 
+			runtimeError(vm, "Instance's 'toString' method must return a string.");
+			*hasError = true;
+			return NULL;
+		}
+		return AS_STRING(stringForm);
 	}
 	else if (tableGet(&instance->klass->methods, copyString(vm, "toString", 8), &method)) {
-		bool hasError = false;
-		Value stringForm = callDragonFromNative(vm, method, 0, &hasError);
-		if (!hasError) return AS_STRING(stringForm);
+		Value stringForm = callDragonFromNative(vm, method, 0, hasError);
+		if (!IS_STRING(stringForm)) {
+			runtimeError(vm, "Instance's 'toString' method must return a string.");
+			*hasError = true;
+			return NULL;
+		}
+		return AS_STRING(stringForm);
 	}
 
 	return makeStringf(vm, "<instance %s>", instance->klass->name->chars);
 }
 
-ObjString* objectToString(VM* vm, Value value) {
+ObjString* objectToString(VM* vm, Value value, bool* hasError) {
 	switch (OBJ_TYPE(value)) {
 		case OBJ_BOUND_METHOD:
 			return functionToString(vm, AS_BOUND_METHOD(value)->method->function);
 		case OBJ_CLASS:
 			return makeStringf(vm, "<class %s>", AS_CLASS(value)->name->chars);
 		case OBJ_INSTANCE:
-			return instanceToString(vm, AS_INSTANCE(value));
+			return instanceToString(vm, AS_INSTANCE(value), hasError);
 		case OBJ_CLOSURE:
 			return functionToString(vm, AS_CLOSURE(value)->function);
 		case OBJ_FUNCTION:
@@ -244,7 +252,8 @@ ObjString* objectToRepr(VM* vm, Value value) {
 		case OBJ_FUNCTION:
 		case OBJ_NATIVE:
 		case OBJ_UPVALUE:
-			return objectToString(vm, value);
+			// The above types cannot fail.
+			return objectToString(vm, value, NULL);
 		case OBJ_INSTANCE:
 			return makeStringf(vm, "<instance %s>", AS_INSTANCE(value)->klass->name->chars);
 		case OBJ_STRING:

--- a/src/object.c
+++ b/src/object.c
@@ -55,9 +55,10 @@ ObjFunction* newFunction(VM* vm) {
 	return function;
 }
 
-ObjNative* newNative(VM* vm, NativeFn function) {
+ObjNative* newNative(VM* vm, size_t arity, NativeFn function) {
 	ObjNative* native = ALLOCATE_OBJ(vm, ObjNative, OBJ_NATIVE);
 	native->function = function;
+	native->arity = arity;
 	return native;
 }
 

--- a/src/object.h
+++ b/src/object.h
@@ -87,7 +87,7 @@ ObjUpvalue* newUpvalue(VM* vm, Value* slot);
 ObjString* takeString(VM* vm, char* chars, size_t length);
 ObjString* copyString(VM* vm, const char* chars, size_t length);
 ObjString* makeStringf(VM* vm, const char* format, ...);
-ObjString* objectToString(VM* vm, Value value);
+ObjString* objectToString(VM* vm, Value value, bool* hasError);
 ObjString* objectToRepr(VM* vm, Value value);
 
 static inline bool isObjType(Value value, ObjType type) {

--- a/src/object.h
+++ b/src/object.h
@@ -35,6 +35,7 @@ typedef Value(*NativeFn)(VM* vm, uint8_t argCount, Value* args);
 typedef struct {
 	Obj obj;
 	NativeFn function;
+	size_t arity;
 } ObjNative;
 
 struct ObjUpvalue {
@@ -80,7 +81,7 @@ ObjBoundMethod* newBoundMethod(VM* vm, Value receiver, ObjClosure* method);
 ObjClass* newClass(VM* vm, ObjString* name);
 ObjInstance* newInstance(VM* vm, ObjClass* klass);
 ObjFunction* newFunction(VM* vm);
-ObjNative* newNative(VM* vm, NativeFn function);
+ObjNative* newNative(VM* vm, size_t arity, NativeFn function);
 ObjClosure* newClosure(VM* vm, ObjFunction* function);
 ObjUpvalue* newUpvalue(VM* vm, Value* slot);
 ObjString* takeString(VM* vm, char* chars, size_t length);
@@ -108,6 +109,7 @@ static inline bool isObjType(Value value, ObjType type) {
 #define AS_CLOSURE(value) ((ObjClosure*)AS_OBJ(value))
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
 #define AS_INSTANCE(value) ((ObjInstance*)AS_OBJ(value))
-#define AS_NATIVE(value) (((ObjNative*)AS_OBJ(value))->function)
+#define AS_NATIVE(value) ((ObjNative*)AS_OBJ(value))
+#define AS_NATIVE_FN(value) (((ObjNative*)AS_OBJ(value))->function)
 #define AS_STRING(value) ((ObjString*)AS_OBJ(value))
 #define AS_CSTRING(value) (((ObjString*)AS_OBJ(value))->chars)

--- a/src/object.h
+++ b/src/object.h
@@ -30,7 +30,7 @@ struct ObjFunction {
 	ObjString* name;
 };
 
-typedef Value(*NativeFn)(VM* vm, uint8_t argCount, Value* args);
+typedef Value(*NativeFn)(VM* vm, uint8_t argCount, Value* args, bool* hasError);
 
 typedef struct {
 	Obj obj;

--- a/src/value.c
+++ b/src/value.c
@@ -48,7 +48,7 @@ ObjString* numberToString(VM* vm, double value) {
 	return makeStringf(vm, "%g", value);
 }
 
-ObjString* valueToString(VM* vm, Value value) {
+ObjString* valueToString(VM* vm, Value value, bool* hasError) {
 	switch (value.type) {
 		case VAL_BOOL:
 			return AS_BOOL(value) ? copyString(vm, "true", 4) : copyString(vm, "false", 5);
@@ -57,7 +57,7 @@ ObjString* valueToString(VM* vm, Value value) {
 		case VAL_NUMBER:
 			return numberToString(vm, AS_NUMBER(value));
 		case VAL_OBJ:
-			return objectToString(vm, value);
+			return objectToString(vm, value, hasError);
 	}
 }
 
@@ -66,7 +66,8 @@ ObjString* valueToRepr(VM* vm, Value value) {
 		case VAL_BOOL: 
 		case VAL_NULL:
 		case VAL_NUMBER:
-			return valueToString(vm, value);
+			// The above types cannot fail.
+			return valueToString(vm, value, NULL);
 		case VAL_OBJ:
 			return objectToRepr(vm, value);
 	}

--- a/src/value.h
+++ b/src/value.h
@@ -35,7 +35,7 @@ void initValueArray(ValueArray* array);
 void freeValueArray(VM* vm, ValueArray* array);
 void writeValueArray(VM* vm, ValueArray* array, Value value);
 ObjString* valueToRepr(VM* vm, Value value);
-ObjString* valueToString(VM* vm, Value value);
+ObjString* valueToString(VM* vm, Value value, bool* hasError);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -240,8 +240,23 @@ static bool invoke(VM* vm, ObjString* name, uint8_t argCount) {
 }
 
 static void concatenate(VM* vm) {
-	ObjString* b = valueToString(vm, peek(vm, 0));
-	ObjString* a = valueToString(vm, peek(vm, 1));
+	ObjString* b;
+	ObjString* a;
+	// Swaps stack so that .toString() implicit call functions (calling convention)
+	if (IS_INSTANCE(peek(vm, 1))) {
+		Value valB = pop(vm);
+		Value valA = pop(vm);
+		push(vm, valB);
+		push(vm, valA);
+
+		b = valueToString(vm, peek(vm, 1));
+		a = valueToString(vm, peek(vm, 0));
+	}
+	else {
+		b = valueToString(vm, peek(vm, 0));
+		a = valueToString(vm, peek(vm, 1));
+	}
+	
 
 	size_t length = a->length + b->length;
 	char* chars = ALLOCATE(vm, char, length + 1);

--- a/src/vm.c
+++ b/src/vm.c
@@ -5,44 +5,11 @@
 #include "object.h"
 #include "memory.h"
 #include "leb128.h"
+#include "natives.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
-#include <time.h>
 #include <math.h>
-
-static void defineNative(VM* vm, const char* name, size_t arity, NativeFn function);
-static void runtimeError(VM* vm, const char* format, ...);
-
-static Value clockNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	return NUMBER_VAL((double)clock() / CLOCKS_PER_SEC);
-}
-
-static Value printNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	for (size_t i = 0; i < argCount; i++) {
-		printf("%s", valueToString(vm, args[i])->chars);
-		printf(" ");
-	}
-	printf("\n");
-	return NULL_VAL;
-}
-
-static Value toStringNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	return OBJ_VAL(valueToString(vm, args[0]));
-}
-
-static Value reprNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	return OBJ_VAL(valueToRepr(vm, args[0]));
-}
-
-static Value sqrtNative(VM* vm, uint8_t argCount, Value* args, bool* hasError) {
-	if (!IS_NUMBER(args[0])) {
-		runtimeError(vm, "Expected number as first argument to sqrt.");
-		*hasError = true;
-		return NULL_VAL;
-	}
-	return NUMBER_VAL(sqrt(AS_NUMBER(args[0])));
-}
 
 static void resetStack(VM* vm) {
 	vm->stackTop = vm->stack;
@@ -75,11 +42,7 @@ void initVM(VM* vm) {
 
 	tableSet(vm, &vm->globals, copyString(vm, "NaN", 3), NUMBER_VAL(nan("0")));
 	tableSet(vm, &vm->globals, copyString(vm, "Infinity", 8), NUMBER_VAL(INFINITY));
-	defineNative(vm, "toString", 1, toStringNative);
-	defineNative(vm, "repr", 1, reprNative);
-	defineNative(vm, "clock", 0, clockNative);
-	defineNative(vm, "sqrt", 1, sqrtNative);
-	defineNative(vm, "print", 1, printNative);
+	defineGlobalNatives(vm);
 }
 
 void freeVM(VM* vm) {
@@ -103,7 +66,7 @@ static Value peek(VM* vm, size_t distance) {
 	return vm->stackTop[-1 - distance];
 }
 
-static void runtimeError(VM* vm, const char* format, ...) {
+void runtimeError(VM* vm, const char* format, ...) {
 	va_list args;
 	va_start(args, format);
 	vfprintf(stderr, format, args);
@@ -159,14 +122,6 @@ static void closeUpvalues(VM* vm, Value* last) {
 		upvalue->location = &upvalue->closed;
 		vm->openUpvalues = upvalue->next;
 	}
-}
-
-static void defineNative(VM* vm, const char* name, size_t arity, NativeFn function) {
-	push(vm, OBJ_VAL(copyString(vm, name, strlen(name))));
-	push(vm, OBJ_VAL(newNative(vm, arity, function)));
-	tableSet(vm, &vm->globals, AS_STRING(vm->stack[0]), vm->stack[1]);
-	pop(vm);
-	pop(vm);
 }
 
 static bool call(VM* vm, ObjClosure* closure, uint8_t argCount) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -143,7 +143,7 @@ static bool call(VM* vm, ObjClosure* closure, uint8_t argCount) {
 	return true;
 }
 
-static bool callValue(VM* vm, Value callee, uint8_t argCount) {
+bool callValue(VM* vm, Value callee, uint8_t argCount) {
 	if (IS_OBJ(callee)) {
 		switch (OBJ_TYPE(callee)) {
 			case OBJ_BOUND_METHOD: {
@@ -265,8 +265,9 @@ static inline bool isInteger(double value) {
 	return floor(value) == value;
 }
 
-static InterpreterResult run(VM* vm) {
+static InterpreterResult fetchExecute(VM* vm, bool isFunctionCall) {
 	CallFrame* frame = &vm->frames[vm->frameCount - 1];
+	size_t baseFrameCount = vm->frameCount - 1;
 #define READ_BYTE() (*frame->ip++)
 #define READ_SHORT() (frame->ip += 2, (uint16_t)((frame->ip[-2] << 8) | frame->ip[-1]))
 #define READ_CONSTANT() (getConstant(frame))
@@ -299,8 +300,330 @@ static InterpreterResult run(VM* vm) {
 		push(vm, NUMBER_VAL((double)(aInt op bInt))); \
 	} while (false)
 
+	uint8_t instruction;
+	switch (instruction = READ_BYTE()) {
+
+		case OP_CONSTANT: {
+			Value constant = READ_CONSTANT();
+			push(vm, constant);
+			break;
+		}
+
+		case OP_NULL: push(vm, NULL_VAL); break;
+		case OP_TRUE: push(vm, BOOL_VAL(true)); break;
+		case OP_FALSE: push(vm, BOOL_VAL(false)); break;
+		case OP_OBJECT: push(vm, OBJ_VAL(vm->objectClass)); break;
+
+		case OP_GET_GLOBAL: {
+			ObjString* name = READ_STRING();
+			Value value;
+			if (!tableGet(&vm->globals, name, &value)) {
+				runtimeError(vm, "Undefined variable '%s'.", name->chars);
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			push(vm, value);
+			break;
+		}
+
+		case OP_DEFINE_GLOBAL: {
+			ObjString* name = READ_STRING();
+			tableSet(vm, &vm->globals, name, peek(vm, 0));
+			pop(vm);
+			break;
+		}
+
+		case OP_SET_GLOBAL: {
+			ObjString* name = READ_STRING();
+			if (tableSet(vm, &vm->globals, name, peek(vm, 0))) {
+				tableDelete(&vm->globals, name);
+				runtimeError(vm, "Undefined variable '%s'.", name->chars);
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_GET_LOCAL: {
+			uint8_t slot = READ_BYTE();
+			push(vm, frame->slots[slot]);
+			break;
+		}
+
+		case OP_SET_LOCAL: {
+			uint8_t slot = READ_BYTE();
+			frame->slots[slot] = peek(vm, 0);
+			break;
+		}
+
+		case OP_GET_UPVALUE: {
+			uint8_t slot = READ_BYTE();
+			push(vm, *frame->closure->upvalues[slot]->location);
+			break;
+		}
+
+		case OP_SET_UPVALUE: {
+			uint8_t slot = READ_BYTE();
+			*frame->closure->upvalues[slot]->location = peek(vm, 0);
+			break;
+		}
+
+		case OP_CLOSE_UPVALUE: {
+			closeUpvalues(vm, vm->stackTop - 1);
+			pop(vm);
+			break;
+		}
+
+		case OP_GET_PROPERTY: {
+			if (!IS_INSTANCE(peek(vm, 0))) {
+				runtimeError(vm, "Only instances contain properties.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			ObjInstance* instance = AS_INSTANCE(peek(vm, 0));
+			ObjString* name = READ_STRING();
+
+			Value value;
+			if (tableGet(&instance->fields, name, &value)) {
+				pop(vm);
+				push(vm, value);
+				break;
+			}
+			if (!bindMethod(vm, instance->klass, name)) {
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_SET_PROPERTY: {
+			if (!IS_INSTANCE(peek(vm, 1))) {
+				runtimeError(vm, "Only instances contain fields.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			ObjInstance* instance = AS_INSTANCE(peek(vm, 1));
+			tableSet(vm, &instance->fields, READ_STRING(), peek(vm, 0));
+			Value value = pop(vm);
+			pop(vm);
+			push(vm, value);
+			break;
+		}
+
+		case OP_SET_PROPERTY_KV: {
+			if (!IS_INSTANCE(peek(vm, 1))) {
+				runtimeError(vm, "Only instances contain fields.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			ObjInstance* instance = AS_INSTANCE(peek(vm, 1));
+			tableSet(vm, &instance->fields, READ_STRING(), peek(vm, 0));
+			pop(vm);
+			break;
+		}
+
+		case OP_GET_SUPER: {
+			ObjString* name = READ_STRING();
+			ObjClass* superclass = AS_CLASS(pop(vm));
+
+			if (!bindMethod(vm, superclass, name)) {
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_POP: pop(vm); break;
+
+		case OP_NOT:
+			push(vm, BOOL_VAL(isFalsey(pop(vm))));
+			break;
+
+		case OP_NEGATE:
+			if (!IS_NUMBER(peek(vm, 0))) {
+				runtimeError(vm, "Operand must be a number.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			push(vm, NUMBER_VAL(-AS_NUMBER(pop(vm))));
+			break;
+		case OP_ADD: {
+			if (IS_STRING(peek(vm, 0)) || IS_STRING(peek(vm, 1))) {
+				concatenate(vm);
+			}
+			else if (IS_NUMBER(peek(vm, 0)) && IS_NUMBER(peek(vm, 1))) {
+				double b = AS_NUMBER(pop(vm));
+				double a = AS_NUMBER(pop(vm));
+				push(vm, NUMBER_VAL(a + b));
+			}
+			else {
+				runtimeError(vm, "Operands must be numbers or strings");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+		case OP_SUB: BINARY_OP(NUMBER_VAL, -); break;
+		case OP_MUL: BINARY_OP(NUMBER_VAL, *); break;
+		case OP_DIV: BINARY_OP(NUMBER_VAL, / ); break;
+
+		case OP_BIT_NOT: {
+			if (!IS_NUMBER(peek(vm, 0))) {
+				runtimeError(vm, "Operand must be a number.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			double value = AS_NUMBER(pop(vm));
+			if (!isInteger(value)) {
+				runtimeError(vm, "Operand must be an integer.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			intmax_t valInt = (intmax_t)value;
+			push(vm, NUMBER_VAL((double)~valInt));
+			break;
+		}
+
+		case OP_AND: BITWISE_BINARY_OP(&); break;
+		case OP_OR: BITWISE_BINARY_OP(| ); break;
+		case OP_XOR: BITWISE_BINARY_OP(^); break;
+		case OP_LSH: BITWISE_BINARY_OP(<< ); break;
+		case OP_ASH: BITWISE_BINARY_OP(>> ); break;
+		case OP_RSH: {
+			if (!IS_NUMBER(peek(vm, 0)) || !IS_NUMBER(peek(vm, 1))) {
+				runtimeError(vm, "Operands must be numbers.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			double b = AS_NUMBER(pop(vm));
+			double a = AS_NUMBER(pop(vm));
+			if (!isInteger(a) || !isInteger(b)) {
+				runtimeError(vm, "Operands must be integers.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			uintmax_t aInt = (uintmax_t)a;
+			uintmax_t bInt = (uintmax_t)b;
+			push(vm, NUMBER_VAL(aInt >> bInt));
+			break;
+		}
+
+		case OP_EQUAL: {
+			Value b = pop(vm);
+			Value a = pop(vm);
+			push(vm, BOOL_VAL(valuesEqual(a, b)));
+			break;
+		}
+		case OP_GREATER: BINARY_OP(BOOL_VAL, > ); break;
+		case OP_LESS: BINARY_OP(BOOL_VAL, < ); break;
+
+		case OP_JUMP_IF_FALSE: {
+			uint16_t offset = READ_SHORT();
+			if (isFalsey(pop(vm))) frame->ip += offset;
+			break;
+		}
+
+		case OP_JUMP_IF_FALSE_SC: {
+			uint16_t offset = READ_SHORT();
+			if (isFalsey(peek(vm, 0))) frame->ip += offset;
+			break;
+		}
+
+		case OP_JUMP: {
+			uint16_t offset = READ_SHORT();
+			frame->ip += offset;
+			break;
+		}
+
+		case OP_LOOP: {
+			uint16_t offset = READ_SHORT();
+			frame->ip -= offset;
+			break;
+		}
+
+		case OP_CALL: {
+			uint8_t argCount = READ_BYTE();
+			if (!callValue(vm, peek(vm, argCount), argCount)) {
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_CLOSURE: {
+			ObjFunction* function = AS_FUNCTION(READ_CONSTANT());
+			ObjClosure* closure = newClosure(vm, function);
+			push(vm, OBJ_VAL(closure));
+			for (size_t i = 0; i < closure->upvalueCount; i++) {
+				uint8_t isLocal = READ_BYTE();
+				uint8_t index = READ_BYTE();
+				if (isLocal) {
+					closure->upvalues[i] = captureUpvalue(vm, frame->slots + index);
+				}
+				else {
+					closure->upvalues[i] = frame->closure->upvalues[index];
+				}
+			}
+			break;
+		}
+
+		case OP_CLASS:
+			push(vm, OBJ_VAL(newClass(vm, READ_STRING())));
+			break;
+
+		case OP_INHERIT: {
+			Value superclass = peek(vm, 1);
+			if (!IS_CLASS(superclass)) {
+				runtimeError(vm, "Superclass must be a class.");
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			ObjClass* subclass = AS_CLASS(peek(vm, 0));
+			tableAddAll(vm, &AS_CLASS(superclass)->methods, &subclass->methods);
+			pop(vm);
+			break;
+		}
+
+		case OP_METHOD:
+			defineMethod(vm, READ_STRING());
+			break;
+
+		case OP_INVOKE: {
+			ObjString* method = READ_STRING();
+			uint8_t argCount = READ_BYTE();
+			if (!invoke(vm, method, argCount)) {
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_SUPER_INVOKE: {
+			ObjString* method = READ_STRING();
+			uint8_t argCount = READ_BYTE();
+			ObjClass* superclass = AS_CLASS(pop(vm));
+			if (!invokeFromClass(vm, superclass, method, argCount)) {
+				return INTERPRETER_RUNTIME_ERR;
+			}
+			break;
+		}
+
+		case OP_RETURN: {
+			Value value = pop(vm);
+			closeUpvalues(vm, frame->slots);
+			vm->frameCount--;
+			if ((isFunctionCall && vm->frameCount == baseFrameCount) || vm->frameCount == 0) {
+				if (isFunctionCall) {
+					push(vm, value);
+				}
+				else {
+					pop(vm);
+				}
+				return INTERPRETER_OK;
+			}
+
+			vm->stackTop = frame->slots;
+			push(vm, value);
+			break;
+		}
+	}
+	return INTERPRETER_CONTINUE;
+#undef READ_BYTE
+#undef READ_SHORT
+#undef READ_CONSTANT
+#undef READ_STRING
+#undef BINARY_OP
+}
+
+Value runFunction(VM* vm, bool* hasError) {
+	InterpreterResult result;
 	for (;;) {
 #ifdef DEBUG_TRACE_EXECUTION
+		CallFrame* frame = &vm->frames[vm->frameCount - 1];
 		printf("     ");
 		for (Value* slot = vm->stack; slot < vm->stackTop; slot++) {
 			printf("[ ");
@@ -312,322 +635,34 @@ static InterpreterResult run(VM* vm) {
 		disassembleInstruction(vm, &frame->closure->function->chunk, (int)(frame->ip - frame->closure->function->chunk.code));
 #endif
 
-		uint8_t instruction;
-		switch (instruction = READ_BYTE()) {
-
-			case OP_CONSTANT: {
-				Value constant = READ_CONSTANT();
-				push(vm, constant);
-				break;
-			}
-
-			case OP_NULL: push(vm, NULL_VAL); break;
-			case OP_TRUE: push(vm, BOOL_VAL(true)); break;
-			case OP_FALSE: push(vm, BOOL_VAL(false)); break;
-			case OP_OBJECT: push(vm, OBJ_VAL(vm->objectClass)); break;
-
-			case OP_GET_GLOBAL: {
-				ObjString* name = READ_STRING();
-				Value value;
-				if (!tableGet(&vm->globals, name, &value)) {
-					runtimeError(vm, "Undefined variable '%s'.", name->chars);
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				push(vm, value);
-				break;
-			}
-
-			case OP_DEFINE_GLOBAL: {
-				ObjString* name = READ_STRING();
-				tableSet(vm, &vm->globals, name, peek(vm, 0));
-				pop(vm);
-				break;
-			}
-
-			case OP_SET_GLOBAL: {
-				ObjString* name = READ_STRING();
-				if (tableSet(vm, &vm->globals, name, peek(vm, 0))) {
-					tableDelete(&vm->globals, name);
-					runtimeError(vm, "Undefined variable '%s'.", name->chars);
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				break;
-			}
-
-			case OP_GET_LOCAL: {
-				uint8_t slot = READ_BYTE();
-				push(vm, frame->slots[slot]);
-				break;
-			}
-
-			case OP_SET_LOCAL: {
-				uint8_t slot = READ_BYTE();
-				frame->slots[slot] = peek(vm, 0);
-				break;
-			}
-
-			case OP_GET_UPVALUE: {
-				uint8_t slot = READ_BYTE();
-				push(vm, *frame->closure->upvalues[slot]->location);
-				break;
-			}
-
-			case OP_SET_UPVALUE: {
-				uint8_t slot = READ_BYTE();
-				*frame->closure->upvalues[slot]->location = peek(vm, 0);
-				break;
-			}
-
-			case OP_CLOSE_UPVALUE: {
-				closeUpvalues(vm, vm->stackTop - 1);
-				pop(vm);
-				break;
-			}
-
-			case OP_GET_PROPERTY: {
-				if (!IS_INSTANCE(peek(vm, 0))) {
-					runtimeError(vm, "Only instances contain properties.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				ObjInstance* instance = AS_INSTANCE(peek(vm, 0));
-				ObjString* name = READ_STRING();
-
-				Value value;
-				if (tableGet(&instance->fields, name, &value)) {
-					pop(vm);
-					push(vm, value);
-					break;
-				}
-				if (!bindMethod(vm, instance->klass, name)) {
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				break;
-			}
-
-			case OP_SET_PROPERTY: {
-				if (!IS_INSTANCE(peek(vm, 1))) {
-					runtimeError(vm, "Only instances contain fields.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				ObjInstance* instance = AS_INSTANCE(peek(vm, 1));
-				tableSet(vm, &instance->fields, READ_STRING(), peek(vm, 0));
-				Value value = pop(vm);
-				pop(vm);
-				push(vm, value);
-				break;
-			}
-
-			case OP_SET_PROPERTY_KV: {
-				if (!IS_INSTANCE(peek(vm, 1))) {
-					runtimeError(vm, "Only instances contain fields.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				ObjInstance* instance = AS_INSTANCE(peek(vm, 1));
-				tableSet(vm, &instance->fields, READ_STRING(), peek(vm, 0));
-				pop(vm);
-				break;
-			}
-
-			case OP_GET_SUPER: {
-				ObjString* name = READ_STRING();
-				ObjClass* superclass = AS_CLASS(pop(vm));
-
-				if (!bindMethod(vm, superclass, name)) {
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				break;
-			}
-
-			case OP_POP: pop(vm); break;
-
-			case OP_NOT:
-				push(vm, BOOL_VAL(isFalsey(pop(vm))));
-				break;
-
-			case OP_NEGATE: 
-				if (!IS_NUMBER(peek(vm, 0))) {
-					runtimeError(vm, "Operand must be a number.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				push(vm, NUMBER_VAL(-AS_NUMBER(pop(vm)))); 
-				break;
-			case OP_ADD: {
-				if (IS_STRING(peek(vm, 0)) || IS_STRING(peek(vm, 1))) {
-					concatenate(vm);
-				}
-				else if (IS_NUMBER(peek(vm, 0)) && IS_NUMBER(peek(vm, 1))) {
-					double b = AS_NUMBER(pop(vm));
-					double a = AS_NUMBER(pop(vm));
-					push(vm, NUMBER_VAL(a + b));
-				}
-				else {
-					runtimeError(vm, "Operands must be numbers or strings");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				break;
-			}
-			case OP_SUB: BINARY_OP(NUMBER_VAL, -); break;
-			case OP_MUL: BINARY_OP(NUMBER_VAL, *); break;
-			case OP_DIV: BINARY_OP(NUMBER_VAL, /); break;
-
-			case OP_BIT_NOT: {
-				if (!IS_NUMBER(peek(vm, 0))) {
-					runtimeError(vm, "Operand must be a number.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				double value = AS_NUMBER(pop(vm));
-				if (!isInteger(value)) {
-					runtimeError(vm, "Operand must be an integer.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				intmax_t valInt = (intmax_t)value;
-				push(vm, NUMBER_VAL((double)~valInt));
-				break;
-			}
-
-			case OP_AND: BITWISE_BINARY_OP(&); break;
-			case OP_OR: BITWISE_BINARY_OP(|); break;
-			case OP_XOR: BITWISE_BINARY_OP(^); break;
-			case OP_LSH: BITWISE_BINARY_OP(<<); break;
-			case OP_ASH: BITWISE_BINARY_OP(>>); break;
-			case OP_RSH: {
-				if (!IS_NUMBER(peek(vm, 0)) || !IS_NUMBER(peek(vm, 1))) {
-						runtimeError(vm, "Operands must be numbers.");
-						return INTERPRETER_RUNTIME_ERR;
-				}
-				double b = AS_NUMBER(pop(vm));
-				double a = AS_NUMBER(pop(vm));
-				if (!isInteger(a) || !isInteger(b)) {
-					runtimeError(vm, "Operands must be integers.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				uintmax_t aInt = (uintmax_t)a;
-				uintmax_t bInt = (uintmax_t)b;
-				push(vm, NUMBER_VAL(aInt >> bInt));
-				break;
-			}
-
-			case OP_EQUAL: {
-				Value b = pop(vm);
-				Value a = pop(vm);
-				push(vm, BOOL_VAL(valuesEqual(a, b)));
-				break;
-			}
-			case OP_GREATER: BINARY_OP(BOOL_VAL, >); break;
-			case OP_LESS: BINARY_OP(BOOL_VAL, <); break;
-
-			case OP_JUMP_IF_FALSE: {
-				uint16_t offset = READ_SHORT();
-				if (isFalsey(pop(vm))) frame->ip += offset;
-				break;
-			}
-
-			case OP_JUMP_IF_FALSE_SC: {
-				uint16_t offset = READ_SHORT();
-				if (isFalsey(peek(vm, 0))) frame->ip += offset;
-				break;
-			}
-
-			case OP_JUMP: {
-				uint16_t offset = READ_SHORT();
-				frame->ip += offset;
-				break;
-			}
-
-			case OP_LOOP: {
-				uint16_t offset = READ_SHORT();
-				frame->ip -= offset;
-				break;
-			}
-
-			case OP_CALL: {
-				uint8_t argCount = READ_BYTE();
-				if (!callValue(vm, peek(vm, argCount), argCount)) {
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				frame = &vm->frames[vm->frameCount - 1];
-				break;
-			}
-
-			case OP_CLOSURE: {
-				ObjFunction* function = AS_FUNCTION(READ_CONSTANT());
-				ObjClosure* closure = newClosure(vm, function);
-				push(vm, OBJ_VAL(closure));
-				for (size_t i = 0; i < closure->upvalueCount; i++) {
-					uint8_t isLocal = READ_BYTE();
-					uint8_t index = READ_BYTE();
-					if (isLocal) {
-						closure->upvalues[i] = captureUpvalue(vm, frame->slots + index);
-					}
-					else {
-						closure->upvalues[i] = frame->closure->upvalues[index];
-					}
-				}
-				break;
-			}
-
-			case OP_CLASS:
-				push(vm, OBJ_VAL(newClass(vm, READ_STRING())));
-				break;
-
-			case OP_INHERIT: {
-				Value superclass = peek(vm, 1);
-				if(!IS_CLASS(superclass)) {
-					runtimeError(vm, "Superclass must be a class.");
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				ObjClass* subclass = AS_CLASS(peek(vm, 0));
-				tableAddAll(vm, &AS_CLASS(superclass)->methods, &subclass->methods);
-				pop(vm);
-				break;
-			}
-
-			case OP_METHOD:
-				defineMethod(vm, READ_STRING());
-				break;
-
-			case OP_INVOKE: {
-				ObjString* method = READ_STRING();
-				uint8_t argCount = READ_BYTE();
-				if (!invoke(vm, method, argCount)) {
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				frame = &vm->frames[vm->frameCount - 1];
-				break;
-			}
-
-			case OP_SUPER_INVOKE: {
-				ObjString* method = READ_STRING();
-				uint8_t argCount = READ_BYTE();
-				ObjClass* superclass = AS_CLASS(pop(vm));
-				if (!invokeFromClass(vm, superclass, method, argCount)) {
-					return INTERPRETER_RUNTIME_ERR;
-				}
-				frame = &vm->frames[vm->frameCount - 1];
-				break;
-			}
-
-			case OP_RETURN: {
-				Value value = pop(vm);
-				closeUpvalues(vm, frame->slots);
-				vm->frameCount--;
-				if (vm->frameCount == 0) {
-					pop(vm);
-					return INTERPRETER_OK;
-				}
-
-				vm->stackTop = frame->slots;
-				push(vm, value);
-				frame = &vm->frames[vm->frameCount - 1];
-				break;
-			}
-		}
+		result = fetchExecute(vm, true);
+		if (result != INTERPRETER_CONTINUE) break;
 	}
-#undef READ_BYTE
-#undef READ_SHORT
-#undef READ_CONSTANT
-#undef READ_STRING
-#undef BINARY_OP
+	if (result != INTERPRETER_OK) {
+		*hasError = true;
+		return NULL_VAL;
+	}
+	return pop(vm);
+}
+
+static InterpreterResult run(VM* vm) {
+	for (;;) {
+#ifdef DEBUG_TRACE_EXECUTION
+		CallFrame* frame = &vm->frames[vm->frameCount - 1];
+		printf("     ");
+		for (Value* slot = vm->stack; slot < vm->stackTop; slot++) {
+			printf("[ ");
+			printf("%s", valueToRepr(vm, *slot)->chars);
+			printf(" ]");
+		}
+		printf("\n");
+
+		disassembleInstruction(vm, &frame->closure->function->chunk, (int)(frame->ip - frame->closure->function->chunk.code));
+#endif
+
+		InterpreterResult result = fetchExecute(vm, false);
+		if (result != INTERPRETER_CONTINUE) return result;
+	}
 }
 
 InterpreterResult interpret(VM* vm, const char* source) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -35,6 +35,7 @@ struct VM {
 
 typedef enum {
 	INTERPRETER_OK,
+	INTERPRETER_CONTINUE,
 	INTERPRETER_COMPILER_ERR,
 	INTERPRETER_RUNTIME_ERR
 } InterpreterResult;
@@ -43,5 +44,7 @@ void initVM(VM* vm);
 void freeVM(VM* vm);
 InterpreterResult interpret(VM* vm, const char* source);
 void runtimeError(VM* vm, const char* format, ...);
+bool callValue(VM* vm, Value callee, uint8_t argCount);
+Value runFunction(VM* vm, bool* hasError);
 void push(VM* vm, Value value);
 Value pop(VM* vm);

--- a/src/vm.h
+++ b/src/vm.h
@@ -42,5 +42,6 @@ typedef enum {
 void initVM(VM* vm);
 void freeVM(VM* vm);
 InterpreterResult interpret(VM* vm, const char* source);
+void runtimeError(VM* vm, const char* format, ...);
 void push(VM* vm, Value value);
 Value pop(VM* vm);


### PR DESCRIPTION
This pull request features a few changes to make native methods more useful.
### Native Arity
Native functions now support arity checking, like a normal function. This means that the `args` array can be safely accessed for the elements expected to be given.
### Native Error Handling
Native functions can now set a `hasError` flag, which allows them to signal that an error has occured (such as a type error). This flag is passed by pointer as a parameter.
### Native Calling of Dragon Functions
This change required a major rework to the VM's internals. It allows a native method to request a call to a value, and get the return value from it. This means that the natives can interface with user supplied code easier.
### Implicit toString
Printing, string concatenation, string coercion, and the `toString` global will now implicitly call an instances `toString` method, if available.
Example:
```
class Person {
	toString() {
		return this.name;
	}
}

var p = Person() {
	name: "Fred"
};

print(p); // Fred
```