### PR TITLE
Dynamic stack

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -17,8 +17,19 @@ static void resetStack(VM* vm) {
 	vm->openUpvalues = NULL;
 }
 
-void initVM(VM* vm) {
+static void initializeStack(VM* vm) {
+	vm->shouldGC = false;
+	vm->frameSize = 64;
+	vm->frames = ALLOCATE(vm, CallFrame, vm->frameSize);
+
+	vm->stackSize = 256 * vm->frameSize;
+	vm->stack = ALLOCATE(vm, Value, vm->stackSize);
 	resetStack(vm);
+	vm->shouldGC = true;
+}
+
+void initVM(VM* vm) {
+	initializeStack(vm);
 	vm->objects = NULL;
 	vm->bytesAllocated = 0;
 	vm->nextGC = 1024 * 1024;
@@ -50,6 +61,10 @@ void freeVM(VM* vm) {
 	freeTable(vm, &vm->globals);
 	vm->constructorString = NULL;
 	freeObjects(vm);
+	vm->shouldGC = false;
+	FREE_ARRAY(vm, CallFrame, vm->frames, vm->frameSize);
+	FREE_ARRAY(vm, Value, vm->stack, vm->stackSize);
+	vm->shouldGC = true;
 }
 
 void push(VM* vm, Value value) {
@@ -135,10 +150,23 @@ static bool call(VM* vm, ObjClosure* closure, uint8_t argCount) {
 		return false;
 	}
 
-	//TODO: Dynamic stack
+	
 	if (vm->frameCount == FRAMES_MAX) {
-		runtimeError(vm, "Stack overflow.");
+		runtimeError(vm, "Stack overflow (Max frame: %d).", FRAMES_MAX);
 		return false;
+	}
+
+	if (vm->frameCount + 1 >= vm->frameSize) {
+		size_t oldCapacity = vm->frameSize;
+		vm->frameSize = GROW_CAPACITY(vm->frameSize);
+		vm->frames = GROW_ARRAY(vm, CallFrame, vm->frames, oldCapacity, vm->frameSize);
+
+		size_t oldStackCapacity = vm->stackSize;
+		size_t stackTopDistance = vm->stackTop - vm->stack;
+
+		vm->stackSize = 256 * vm->frameSize;
+		vm->stack = GROW_ARRAY(vm, Value, vm->stack, oldStackCapacity, vm->stackSize);
+		vm->stackTop = vm->stack + stackTopDistance;
 	}
 
 	CallFrame* frame = &vm->frames[vm->frameCount++];

--- a/src/vm.h
+++ b/src/vm.h
@@ -4,8 +4,7 @@
 #include "table.h"
 #include "compiler.h"
 
-#define FRAMES_MAX 64
-#define STACK_MAX (FRAMES_MAX * UINT8_COUNT)
+#define FRAMES_MAX 1024
 
 typedef struct {
 	ObjClosure* closure;
@@ -14,9 +13,11 @@ typedef struct {
 } CallFrame;
 
 struct VM {
-	CallFrame frames[FRAMES_MAX];
+	CallFrame* frames;
 	size_t frameCount;
-	Value stack[STACK_MAX]; //TODO Dynamic stack
+	size_t frameSize;
+	Value* stack;
+	size_t stackSize;
 	Value* stackTop;
 	Table globals;
 	Table strings;


### PR DESCRIPTION
### Dynamic Frame Growth
The internal frames array, used for function calls, was previously a fixed size of 64. It will now dynamically grow as needed, up to a size of 1024.

### Better Stack Traces for Recursive Functions
If a line in a stack trace were to be the same as the previous, it is not printed. Repeated lines will collect until the line changes.
Example:
```
[3] in func
[5] in func
[Previous * 62]
[8] in <script>
```