### PR TITLE
'throw' Will Type Check for Exceptions

### DIFF
--- a/src/exception.c
+++ b/src/exception.c
@@ -29,4 +29,6 @@ void defineExceptionClasses(VM* vm) {
 	defineException(vm, exception, "IndexException");
 	defineException(vm, exception, "UndefinedVariableException");
 	defineException(vm, exception, "StackOverflowException");
+
+	vm->exceptionClass = exception;
 }

--- a/src/memory.c
+++ b/src/memory.c
@@ -90,6 +90,7 @@ static void markRoots(VM* vm) {
 	markTable(vm, &vm->stringMethods);
 	markObject(vm, (Obj*)vm->constructorString);
 	markObject(vm, (Obj*)vm->objectClass);
+	markObject(vm, (Obj*)vm->exceptionClass);
 	if(vm->compiler != NULL) markCompilerRoots(vm->compiler);
 }
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -27,6 +27,7 @@ struct VM {
 	Table stringMethods;
 	ObjString* constructorString;
 	ObjClass* objectClass;
+	ObjClass* exceptionClass;
 	Compiler* compiler;
 	ObjUpvalue* openUpvalues;
 	size_t bytesAllocated;


### PR DESCRIPTION
### Usage
the `throw` keyword will now throw an exception when a non-exception object is passed.
E.g.
```
throw { message: "Oh no!" }; // TypeException
throw Exception { message: "Oh no!" }; // works fine (although bad practice to use the 'Exception' class directly).
```