### PR TITLE
Implement 'input' Function & Fix Native Throw Calls

### DIFF
--- a/src/iterator.h
+++ b/src/iterator.h
@@ -2,5 +2,5 @@
 #include "common.h"
 #include "vm.h"
 
-Value iteratorConstructorNative(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError);
+Value iteratorConstructorNative(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError, ObjInstance** exception);
 void defineIteratorMethods(VM* vm);

--- a/src/natives.h
+++ b/src/natives.h
@@ -3,6 +3,6 @@
 #include "object.h"
 #include "vm.h"
 
-Value callDragonFromNative(VM* vm, Value* bound, Value callee, size_t argCount, bool* hasError);
+Value callDragonFromNative(VM* vm, Value* bound, Value callee, size_t argCount, bool* hasError, ObjInstance** exception);
 void defineNative(VM* vm, Table* table, const char* name, size_t arity, bool varargs, NativeFn function);
 void defineGlobalNatives(VM* vm);

--- a/src/object.c
+++ b/src/object.c
@@ -65,11 +65,12 @@ ObjFunction* newFunction(VM* vm) {
 	return function;
 }
 
-ObjNative* newNative(VM* vm, size_t arity, NativeFn function) {
+ObjNative* newNative(VM* vm, size_t arity, bool varargs, NativeFn function) {
 	ObjNative* native = ALLOCATE_OBJ(vm, ObjNative, OBJ_NATIVE);
 	native->function = function;
 	native->arity = arity;
 	native->isBound = false;
+	native->varargs = varargs;
 	native->bound = NULL_VAL;
 	return native;
 }

--- a/src/object.h
+++ b/src/object.h
@@ -95,7 +95,7 @@ ObjClass* newClass(VM* vm, ObjString* name);
 ObjInstance* newInstance(VM* vm, ObjClass* klass);
 ObjList* newList(VM* vm, ValueArray array);
 ObjFunction* newFunction(VM* vm);
-ObjNative* newNative(VM* vm, size_t arity, NativeFn function);
+ObjNative* newNative(VM* vm, size_t arity, bool varargs, NativeFn function);
 ObjClosure* newClosure(VM* vm, ObjFunction* function);
 ObjUpvalue* newUpvalue(VM* vm, Value* slot);
 ObjString* takeString(VM* vm, char* chars, size_t length);

--- a/src/object.h
+++ b/src/object.h
@@ -34,7 +34,7 @@ struct ObjFunction {
 	ObjString* name;
 };
 
-typedef Value(*NativeFn)(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError);
+typedef Value(*NativeFn)(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError, ObjInstance** exception);
 
 typedef struct {
 	Obj obj;
@@ -78,11 +78,11 @@ typedef struct ObjClass {
 	struct ObjClass* superclass;
 } ObjClass;
 
-typedef struct {
+struct ObjInstance {
 	Obj obj;
 	ObjClass* klass;
 	Table fields;
-} ObjInstance;
+};
 
 typedef struct {
 	Obj obj;
@@ -102,7 +102,7 @@ ObjString* takeString(VM* vm, char* chars, size_t length);
 ObjString* copyString(VM* vm, const char* chars, size_t length);
 ObjString* makeStringf(VM* vm, const char* format, ...);
 ObjString* makeStringvf(VM* vm, const char* format, va_list args);
-ObjString* objectToString(VM* vm, Value value, bool* hasError);
+ObjString* objectToString(VM* vm, Value value, bool* hasError, ObjInstance** exception);
 ObjString* objectToRepr(VM* vm, Value value);
 void defineObjectNatives(VM* vm);
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -4,6 +4,7 @@
 #include "iterator.h"
 #include <string.h>
 #include <math.h>
+#include <stdlib.h>
 
 /*
   Utility for string methods
@@ -124,6 +125,20 @@ static Value stringLengthNative(VM* vm, Value* bound, uint8_t argCount, Value* a
 	return NUMBER_VAL((double)AS_STRING(*bound)->length);
 }
 
+static Value stringParseNumberNative(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError) {
+	char* str = AS_CSTRING(*bound);
+	char* end;
+
+	double result = strtod(str, &end);
+
+	if (end == str || *end != '\0') {
+		*hasError = throwException(vm, "TypeException", "String does not represent a valid number.");
+		return (*hasError) ? NULL_VAL : pop(vm);
+	}
+
+	return NUMBER_VAL(result);
+}
+
 static Value stringRepeatNative(VM* vm, Value* bound, uint8_t argCount, Value* args, bool* hasError) {
 	ObjString* string = AS_STRING(*bound);
 
@@ -220,6 +235,7 @@ void defineStringMethods(VM* vm) {
 	defineNative(vm, &vm->stringMethods, "iterator", 0, false, stringIteratorNative);
 	defineNative(vm, &vm->stringMethods, "lastIndexOf", 1, false, stringLastIndexOfNative);
 	defineNative(vm, &vm->stringMethods, "length", 0, false, stringLengthNative);
+	defineNative(vm, &vm->stringMethods, "parseNumber", 0, false, stringParseNumberNative);
 	defineNative(vm, &vm->stringMethods, "repeat", 1, false, stringRepeatNative);
 	defineNative(vm, &vm->stringMethods, "startsWith", 1, false, stringStartsWithNative);
 	defineNative(vm, &vm->stringMethods, "substring", 2, false, stringSubstringNative);

--- a/src/value.c
+++ b/src/value.c
@@ -49,7 +49,7 @@ ObjString* numberToString(VM* vm, double value) {
 	return makeStringf(vm, "%g", value);
 }
 
-ObjString* valueToString(VM* vm, Value value, bool* hasError) {
+ObjString* valueToString(VM* vm, Value value, bool* hasError, ObjInstance** exception) {
 	switch (value.type) {
 		case VAL_BOOL:
 			return vm->stringConstants[AS_BOOL(value) ? STR_TRUE : STR_FALSE];
@@ -58,7 +58,7 @@ ObjString* valueToString(VM* vm, Value value, bool* hasError) {
 		case VAL_NUMBER:
 			return numberToString(vm, AS_NUMBER(value));
 		case VAL_OBJ:
-			return objectToString(vm, value, hasError);
+			return objectToString(vm, value, hasError, exception);
 	}
 }
 
@@ -68,7 +68,7 @@ ObjString* valueToRepr(VM* vm, Value value) {
 		case VAL_NULL:
 		case VAL_NUMBER:
 			// The above types cannot fail.
-			return valueToString(vm, value, NULL);
+			return valueToString(vm, value, NULL, NULL);
 		case VAL_OBJ:
 			return objectToRepr(vm, value);
 	}

--- a/src/value.h
+++ b/src/value.h
@@ -7,6 +7,7 @@ typedef struct ObjClosure ObjClosure;
 typedef struct ObjFunction ObjFunction;
 typedef struct ObjUpvalue ObjUpvalue;
 typedef struct ObjString ObjString;
+typedef struct ObjInstance ObjInstance;
 typedef struct VM VM;
 
 typedef enum {
@@ -35,7 +36,7 @@ void initValueArray(ValueArray* array);
 void freeValueArray(VM* vm, ValueArray* array);
 void writeValueArray(VM* vm, ValueArray* array, Value value);
 ObjString* valueToRepr(VM* vm, Value value);
-ObjString* valueToString(VM* vm, Value value, bool* hasError);
+ObjString* valueToString(VM* vm, Value value, bool* hasError, ObjInstance** exception);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -953,6 +953,8 @@ static InterpreterResult fetchExecute(VM* vm, bool isFunctionCall) {
 				push(vm, NUMBER_VAL(a + b));
 			}
 			else {
+				pop(vm);
+				pop(vm);
 				if (!throwException(vm, "TypeException", "Operands are invalid for '+' operation.")) return INTERPRETER_RUNTIME_ERR;
 				break;
 			}

--- a/src/vm.c
+++ b/src/vm.c
@@ -144,7 +144,7 @@ static bool throwGeneral(VM* vm, ObjInstance* throwee) {
 	}
 
 	bool hasError = false;
-	ObjString* fullMessage = makeStringf(vm, "%s: %s", throwee->klass->name->chars, valueToString(vm, message, &hasError)->chars);
+	ObjString* fullMessage = makeStringf(vm, "%s: %s", throwee->klass->name->chars, valueToString(vm, message, &hasError, &throwee)->chars);
 	if (hasError) return false;
 
 	writeValueArray(vm, &stackTrace, OBJ_VAL(fullMessage));
@@ -211,6 +211,34 @@ static bool throwGeneral(VM* vm, ObjInstance* throwee) {
 	frame->ip = frame->catchJump;
 
 	return true;
+}
+
+ObjInstance* makeException(VM* vm, const char* name, const char* format, ...) {
+	va_list args;
+	va_start(args, format);
+	ObjString* message = makeStringvf(vm, format, args);
+	va_end(args);
+	push(vm, OBJ_VAL(message));
+
+	ObjString* nameStr = copyString(vm, name, strlen(name));
+
+	Value value;
+	if (!tableGet(&vm->globals, nameStr, &value)) {
+		fprintf(stderr, "Expected '%s' to be available at global scope.", name);
+		return false;
+	}
+	if (!IS_CLASS(value)) {
+		fprintf(stderr, "Expected '%s' to be a class.", name);
+		return false;
+	}
+
+	ObjInstance* instance = newInstance(vm, AS_CLASS(value));
+	push(vm, OBJ_VAL(instance));
+	tableSet(vm, &instance->fields, vm->stringConstants[STR_MESSAGE], OBJ_VAL(message));
+
+	popN(vm, 2);
+	push(vm, OBJ_VAL(instance));
+	return instance;
 }
 
 bool throwException(VM* vm, const char* name, const char* format, ...) {
@@ -395,9 +423,15 @@ bool callValue(VM* vm, Value callee, uint8_t argCount, uint8_t* argsUsed) {
 
 				NativeFn nativeFunction = native->function;
 				bool hasError = false;
+				ObjInstance* exception = NULL;
 
-				Value result = nativeFunction(vm, native->isBound ? &native->bound : NULL, argCount, vm->stackTop - argCount, &hasError);
+				Value result = nativeFunction(vm, native->isBound ? &native->bound : NULL, argCount, vm->stackTop - argCount, &hasError, &exception);
 				vm->stackTop -= ((size_t)argCount) + 1;
+				if (hasError) {
+					pop(vm);
+					push(vm, OBJ_VAL(exception));
+					return throwGeneral(vm, exception);
+				}
 				push(vm, result);
 				return !hasError;
 			}
@@ -493,7 +527,7 @@ static bool invoke(VM* vm, ObjString* name, uint8_t argCount) {
 	return invokeFromClass(vm, instance, instance->klass, name, argCount);
 }
 
-static bool concatenate(VM* vm) {
+static bool concatenate(VM* vm, ObjInstance** exception) {
 	ObjString* b;
 	ObjString* a;
 	bool hasError = false;
@@ -504,12 +538,12 @@ static bool concatenate(VM* vm) {
 		push(vm, valB);
 		push(vm, valA);
 
-		b = valueToString(vm, peek(vm, 1), &hasError);
-		a = valueToString(vm, peek(vm, 0), &hasError);
+		b = valueToString(vm, peek(vm, 1), &hasError, exception);
+		a = valueToString(vm, peek(vm, 0), &hasError, exception);
 	}
 	else {
-		b = valueToString(vm, peek(vm, 0), &hasError);
-		a = valueToString(vm, peek(vm, 1), &hasError);
+		b = valueToString(vm, peek(vm, 0), &hasError, exception);
+		a = valueToString(vm, peek(vm, 1), &hasError, exception);
 	}
 	
 	if (hasError) { 
@@ -943,8 +977,10 @@ static InterpreterResult fetchExecute(VM* vm, bool isFunctionCall) {
 				push(vm, OBJ_VAL(nList));
 			}
 			else if (IS_STRING(peek(vm, 0)) || IS_STRING(peek(vm, 1))) {
-				if (!concatenate(vm)) {
-					return INTERPRETER_RUNTIME_ERR;
+				ObjInstance* exception = NULL;
+				if (!concatenate(vm, &exception)) {
+					if (!throwGeneral(vm, exception)) return INTERPRETER_RUNTIME_ERR;
+					break;
 				}
 			}
 			else if (IS_NUMBER(peek(vm, 0)) && IS_NUMBER(peek(vm, 1))) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -71,7 +71,7 @@ typedef enum {
 void initVM(VM* vm);
 void freeVM(VM* vm);
 InterpreterResult interpret(VM* vm, const char* source);
-bool throwException(VM* vm, const char* name, const char* format, ...);
+ObjInstance* makeException(VM* vm, const char* name, const char* format, ...);
 bool callValue(VM* vm, Value callee, uint8_t argCount, uint8_t* argsUsed);
 bool validateListIndex(VM* vm, size_t listLength, Value indexVal, uintmax_t* dest);
 Value runFunction(VM* vm, bool* hasError);


### PR DESCRIPTION
The `input` function returns a string from `stdin`.
The `parseNumber` string method returns the string as a number, or throws an exception if the string does not represent a number.

The native API has been modified to let exceptions be used without unexpected behaviour.